### PR TITLE
Fix/host to bind to

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,31 @@ builder
   ))
 ```
 
+## Running within docker containers
+
+The plugin will try to use an IP6 address when opening the port for the gRPC server. Docker will only support IP6
+addresses with extra configuration applied and this will not be available by default. To use an IP4 address instead,
+you can either add the host parameter as a command line parameter, or add `hostToBindTo` value to the plugin 
+configuration in the manifest file.
+
+I.e., updated manifest to use 127.0.0.1 as the host to bind to
+
+```json
+{
+  "manifestVersion": 1,
+  "pluginInterfaceVersion": 1,
+  "name": "protobuf",
+  "version": "0.1.8",
+  "executableType": "exec",
+  "entryPoint": "pact-protobuf-plugin",
+  "pluginConfig": {
+    "protocVersion": "3.19.1",
+    "downloadUrl": "https://github.com/protocolbuffers/protobuf/releases/download",
+    "hostToBindTo": "127.0.0.1"
+  }
+}
+```
+
 ## Support
 
 Join us on slack [![slack](https://slack.pact.io/badge.svg)](https://slack.pact.io) in the **#protobufs** channel

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,6 +8,7 @@ use anyhow::anyhow;
 use bytes::{Bytes, BytesMut};
 use maplit::hashmap;
 use pact_matching::{BodyMatchResult, Mismatch};
+use pact_models::json_utils::json_to_string;
 use pact_models::matchingrules::MatchingRule;
 use pact_models::path_exp::DocPath;
 use pact_models::prelude::{ContentType, MatchingRuleCategory, OptionalBody, RuleLogic};
@@ -66,6 +67,12 @@ impl ProtobufPactPlugin {
       error: err.into(),
       ..proto::CompareContentsResponse::default()
     }))
+  }
+
+  pub fn host_to_bind_to(&self) -> Option<String> {
+    self.manifest.plugin_config
+      .get("hostToBindTo")
+      .map(|host| json_to_string(host))
   }
 }
 


### PR DESCRIPTION
Adds configuration (as either a command line parameter or JSON value in the plugin manifest) to allow the host name to bind to to be specified. Fixes issues when running within docker containers where IP6 is not supported.