### PR TITLE
Fix bug resolving enum across multiple files.

### DIFF
--- a/tests/enum.proto
+++ b/tests/enum.proto
@@ -1,5 +1,9 @@
 syntax = "proto3";
 
+package example.enum.package;
+
+import "enum_imported.proto";
+
 enum Values {
   NONE = 0;
   A = 1;
@@ -9,6 +13,7 @@ enum Values {
 
 message MessageIn {
   repeated Values in = 1;
+  repeated Values2 in2 = 2;
 }
 
 message MessageOut {

--- a/tests/enum_imported.proto
+++ b/tests/enum_imported.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package example.enum.package;
+
+enum Values2 {
+    VALUES_2_NONE = 0;
+    VALUES_2_A = 1;
+    VALUES_2_B = 2;
+    VALUES_2_C = 3;
+}

--- a/tests/enum_tests.rs
+++ b/tests/enum_tests.rs
@@ -27,6 +27,9 @@ async fn repeated_enum_test() {
 
         "in": [
           "matching(equalTo, 'A')"
+        ],
+        "in2": [
+          "matching(equalTo, 'VALUES_2_A')"
         ]
       })).await;
       i
@@ -68,12 +71,6 @@ async fn repeated_enum_test() {
         wire_type: WireType::LengthDelimited,
         data: ProtobufFieldData::Enum(1, enum_descriptor.clone())
       },
-      // ProtobufField {
-      //   field_num: 1,
-      //   field_name: "in".to_string(),
-      //   wire_type: WireType::LengthDelimited,
-      //   data: ProtobufFieldData::Enum(1, enum_descriptor.clone())
-      // }
     ];
 
     let result = compare_message(

--- a/tests/simple.proto
+++ b/tests/simple.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package com.pact.protobuf.example;
+
 message MessageIn {
   bool in = 1;
 }


### PR DESCRIPTION
In [utils.rs](https://github.com/pactflow/pact-protobuf-plugin/blob/main/src/utils.rs), the `find_enum_by_name` and `find_enum_by_name_in_message` functions only look at the first descriptor that matches the package name. If there are multiple top-level descriptors with the same package name, the plugin doesn't look at each of them.

The unit test attached reproduces this issue when tested against the previous version.

Issue: https://github.com/pactflow/pact-protobuf-plugin/issues/30