### PR TITLE
Fix merging between plugin config and manifest values.

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -369,7 +369,7 @@ impl ProtobufPactPlugin {
               let val = proto_value_to_json(v);
               match plugin_config.entry(k.clone()) {
                 Entry::Occupied(mut e) => {
-                  e.insert(merge_value(&val, e.get())?);
+                  e.insert(merge_value(e.get(), &val)?);
                 },
                 Entry::Vacant(e) => {
                   e.insert(val);


### PR DESCRIPTION
When passing the protocVersion in the plugin config similar to additionalIncludes, the plugin doesn't adhere to the value passed in. It instead uses the value that's in the manifest.

This is necessary for folks to support M1 macs without needing to update the plugin version.

This fixes https://github.com/pactflow/pact-protobuf-plugin/issues/41