### PR TITLE
chore(ci): macos-12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ ubuntu-latest, windows-latest, macos-latest ]
+        operating-system: [ ubuntu-latest, windows-latest, macos-12 ]
         rust: [ stable ]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
macos-latest moved to arm64 which causes a current test to fail. revert back to original behaviour