### PR TITLE
fix: respect package namespaces when resolving message descriptors

### DIFF
--- a/integrated_tests/imported_message/build.rs
+++ b/integrated_tests/imported_message/build.rs
@@ -1,7 +1,11 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-  tonic_build::configure().include_file("mod.rs").compile(
-    &["primary/primary.proto", "imported/imported.proto"],
-    &["."],
-  )?;
-  Ok(())
+    tonic_build::configure().include_file("mod.rs").compile(
+        &[
+            "primary/primary.proto",
+            "imported/imported.proto",
+            "zimported/zimported.proto",
+        ],
+        &["."],
+    )?;
+    Ok(())
 }

--- a/integrated_tests/imported_message/primary/primary.proto
+++ b/integrated_tests/imported_message/primary/primary.proto
@@ -9,6 +9,7 @@ option java_package = "io.grpc.examples.primary";
 option java_outer_classname = "PrimaryProto";
 
 import "imported/imported.proto";
+import "zimported/zimported.proto";
 
 package primary;
 

--- a/integrated_tests/imported_message/src/lib.rs
+++ b/integrated_tests/imported_message/src/lib.rs
@@ -2,41 +2,41 @@ tonic::include_proto!("mod");
 
 #[cfg(test)]
 mod tests {
-  use std::path::Path;
+    use std::path::Path;
 
-  use crate::primary::primary_client::PrimaryClient;
-  use pact_consumer::mock_server::StartMockServerAsync;
-  use pact_consumer::prelude::*;
-  use serde_json::json;
-  use tonic::IntoRequest;
-  use tracing::info;
+    use crate::primary::primary_client::PrimaryClient;
+    use pact_consumer::mock_server::StartMockServerAsync;
+    use pact_consumer::prelude::*;
+    use serde_json::json;
+    use tonic::IntoRequest;
+    use tracing::info;
 
-  use super::*;
+    use super::*;
 
-  #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-  async fn test_proto_client() {
-    let _ = env_logger::builder().is_test(true).try_init();
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_proto_client() {
+        let _ = env_logger::builder().is_test(true).try_init();
 
-    let mut pact_builder = PactBuilderAsync::new_v4("grpc-consumer-rust", "imported_message");
-    let mock_server = pact_builder
-      .using_plugin("protobuf", None)
-      .await
-      .synchronous_message_interaction(
-        "package namespace not respected",
-        |mut i| async move {
-          let proto_file = Path::new("primary/primary.proto")
-            .canonicalize()
-            .unwrap()
-            .to_string_lossy()
-            .to_string();
-          let proto_include = Path::new(".")
-            .canonicalize()
-            .unwrap()
-            .to_string_lossy()
-            .to_string();
-          info!("proto_file: {}", proto_file);
-          info!("proto_include: {}", proto_include);
-          i.contents_from(json!({
+        let mut pact_builder = PactBuilderAsync::new_v4("grpc-consumer-rust", "imported_message");
+        let mock_server = pact_builder
+            .using_plugin("protobuf", None)
+            .await
+            .synchronous_message_interaction(
+                "package namespace not respected",
+                |mut i| async move {
+                    let proto_file = Path::new("primary/primary.proto")
+                        .canonicalize()
+                        .unwrap()
+                        .to_string_lossy()
+                        .to_string();
+                    let proto_include = Path::new(".")
+                        .canonicalize()
+                        .unwrap()
+                        .to_string_lossy()
+                        .to_string();
+                    info!("proto_file: {}", proto_file);
+                    info!("proto_include: {}", proto_include);
+                    i.contents_from(json!({
                         "pact:proto": proto_file,
                         "pact:proto-service": "Primary/GetRectangle",
                         "pact:content-type": "application/protobuf",
@@ -62,25 +62,25 @@ mod tests {
                             }
                         }
                     }))
+                    .await;
+                    i
+                },
+            )
+            .await
+            .start_mock_server_async(Some("protobuf/transport/grpc"))
             .await;
-          i
-        },
-      )
-      .await
-      .start_mock_server_async(Some("protobuf/transport/grpc"))
-      .await;
 
-    let url = mock_server.url();
+        let url = mock_server.url();
 
-    let mut client = PrimaryClient::connect(url.to_string()).await.unwrap();
-    let request_message = primary::RectangleLocationRequest {
-      x: 180,
-      y: 200,
-      width: 10,
-      length: 20,
-    };
+        let mut client = PrimaryClient::connect(url.to_string()).await.unwrap();
+        let request_message = primary::RectangleLocationRequest {
+            x: 180,
+            y: 200,
+            width: 10,
+            length: 20,
+        };
 
-    let response = client.get_rectangle(request_message.into_request()).await;
-    let _response_message = response.unwrap();
-  }
+        let response = client.get_rectangle(request_message.into_request()).await;
+        let _response_message = response.unwrap();
+    }
 }

--- a/integrated_tests/imported_message/zimported/zimported.proto
+++ b/integrated_tests/imported_message/zimported/zimported.proto
@@ -1,39 +1,39 @@
 
 syntax = "proto3";
 
-option go_package = "github.com/pact-foundation/pact-go/v2/examples/grpc/imported";
+option go_package = "github.com/pact-foundation/pact-go/v2/examples/grpc/zimported";
 option java_multiple_files = true;
-option java_package = "io.grpc.examples.imported";
+option java_package = "io.grpc.examples.zimported";
 option java_outer_classname = "ImportedProto";
 
-package imported;
+package zimported;
 
-service Imported {
+service ZImported {
   rpc GetRectangle(RectangleLocationRequest) returns (RectangleLocationResponse) {}
 }
 
 message Rectangle {
   // The width of the rectangle.
-  int32 width = 1;
+  int32 zwidth = 1;
 
   // The length of the rectangle.
-  int32 length = 2;
+  int32 zlength = 2;
 }
 
 // Request message for GetRectangle method. This message has different fields,
 // but the same name as a message defined in primary.proto
 message RectangleLocationRequest {
-  int32 a = 1;
-  int32 b = 2;
+  int32 zx = 1;
+  int32 zb = 2;
 }
 
 // Response message for GetRectangle method. This message has different fields,
 // but the same name as a message defined in primary.proto
 message RectangleLocationResponse {
-  Point location = 1;
+  Point zlocation = 1;
 }
 
 message Point {
-  int32 latitude = 1;
-  int32 longitude = 2;
+  int32 zlatitude = 1;
+  int32 zlongitude = 2;
 }


### PR DESCRIPTION
## Overview

This change fixes a couple of bugs exposed by @stan-is-hate in https://github.com/pactflow/pact-protobuf-plugin/pull/59 where package namespaces are not taken into account when looking up protobuf messages.

## Testing 
Ran `integrated_tests/imported_message` in a loop ~20 times without a failure locally.