### PR TITLE
fix: update protobuf version to 25.2

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,12 +1,12 @@
 [target.x86_64-unknown-linux-musl]
 pre-build=[
     "apt-get update && apt-get install --assume-yes wget unzip",
-    "wget https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip",
-    "unzip protoc-21.5-linux-x86_64.zip -d /usr/local/"
+    "wget https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-x86_64.zip",
+    "unzip protoc-25.2-linux-x86_64.zip -d /usr/local/"
 ]
 [target.aarch64-unknown-linux-musl]
 pre-build=[
     "dpkg --add-architecture arm64 && apt-get update && apt-get install --assume-yes wget unzip",
-    "wget https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-21.5-linux-x86_64.zip",
-    "unzip protoc-21.5-linux-x86_64.zip -d /usr/local/"
+    "wget https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-25.2-linux-x86_64.zip",
+    "unzip protoc-25.2-linux-x86_64.zip -d /usr/local/"
 ]

--- a/Cross.toml
+++ b/Cross.toml
@@ -7,6 +7,6 @@ pre-build=[
 [target.aarch64-unknown-linux-musl]
 pre-build=[
     "dpkg --add-architecture arm64 && apt-get update && apt-get install --assume-yes wget unzip",
-    "wget https://github.com/protocolbuffers/protobuf/releases/download/v21.5/protoc-25.2-linux-x86_64.zip",
+    "wget https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-x86_64.zip",
     "unzip protoc-25.2-linux-x86_64.zip -d /usr/local/"
 ]

--- a/pact-plugin.json
+++ b/pact-plugin.json
@@ -6,7 +6,7 @@
   "executableType": "exec",
   "entryPoint": "pact-protobuf-plugin",
   "pluginConfig": {
-    "protocVersion": "21.12",
+    "protocVersion": "25.2",
     "downloadUrl": "https://github.com/protocolbuffers/protobuf/releases/download",
     "hostToBindTo": "127.0.0.1"
   }


### PR DESCRIPTION
fixes #63 / #33 

works OOB with MacOS aarch64. 

26.x/27.x fail on MacOS aarch64 for integrations with via pact_ffi for

- php
- swift
- dotnet
- lua