### PR TITLE
chore: upgrade ubuntu runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - operating-system: ubuntu-20.04
+          - operating-system: ubuntu-22.04
             targets: x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-unknown-linux-gnu,aarch64-unknown-linux-musl
           - operating-system: windows-2019
             targets: aarch64-pc-windows-msvc,x86_64-pc-windows-msvc
@@ -53,7 +53,7 @@ jobs:
             echo "flags=--release" >> "$GITHUB_OUTPUT"
           else
             echo "flags=" >> "$GITHUB_OUTPUT"
-          fi 
+          fi
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:


### PR DESCRIPTION
The 20.04 runner have been deprecated and no longer can be used.