### PR TITLE
fix: Update GHA runners to latest windows image OP-33207

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - operating-system: ubuntu-22.04
             targets: x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-unknown-linux-gnu,aarch64-unknown-linux-musl
-          - operating-system: windows-2019
+          - operating-system: windows-latest
             targets: aarch64-pc-windows-msvc,x86_64-pc-windows-msvc
           - operating-system: macos-13
             targets: aarch64-apple-darwin,x86_64-apple-darwin


### PR DESCRIPTION
Replaces #192 which failed due to not having access to secrets.