### PR TITLE
ci: run the repeated_field_contains integrated test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,11 @@ jobs:
           pushd integrated_tests/new_fields/old_provider && cargo test && popd
           pushd integrated_tests/new_fields/new_provider && cargo test && popd
           pushd integrated_tests/repeated_enums && cargo test && popd
+          pushd integrated_tests/repeated_field_contains/consumer && cargo test && popd
+          # Provider tests must run serially: verify_provider_async shuts down the
+          # process-global plugin manager when it completes, so parallel tests tear
+          # down the plugin out from under each other.
+          pushd integrated_tests/repeated_field_contains/provider && cargo test -- --test-threads=1 && popd
           pushd integrated_tests/response_metadata && cargo test && popd
         env:
           RUST_LOG: debug


### PR DESCRIPTION
> **Authorship disclosure: this is AI-generated.** The investigation, the code, the tests, and this description were all produced by an AI agent (Claude Opus) operating on behalf of @stan-is-hate. Please review with that in mind.

Rewritten after @rholshausen's feedback — thanks, and sorry for the noise.

> The reason not all the tests were added to CI is to keep the build time from becoming excessively long. If we want to run all the tests, we should run them in parallel not sequentially

Understood, and the numbers back you up. From the previous run's log, each **top-level** directory costs about **80s**, because each is a separate cargo project that rebuilds the whole dependency tree:

| Directory | Elapsed |
|---|---|
| `default_values` | ~82s |
| `imported_message` | ~79s |
| `matching_maps` | ~80s |
| `new_fields/consumer` | ~78s |
| `new_fields/old_provider` | ~27s (reuses the sibling's deps) |
| `new_fields/new_provider` | ~28s |

So my previous version added roughly **5 minutes** to the job. That was a bad trade for directories nobody asked for.

**This version adds only `repeated_field_contains`** — the one covering `arrayContains` (#236) and the `atLeast`/`atMost` regression test (#241). Consumer ~80s plus provider ~28s, since the provider reuses the consumer's dependency build.

## I was wrong that these tests pass as-is

I claimed all the directories passed. They passed on my 10-core machine; on the CI runner `repeated_field_contains/provider` failed **4 of 7**. Not a matching failure — intermittent transport errors:

```
Request Failed - error sending request for url (http://127.0.0.1:34961/)
client connection error: hyper::Error(UnexpectedMessage)
```

**Cause:** `verify_provider_async` shuts down the **process-global** plugin manager when it completes. The tests run in parallel, so the first one to finish tears the plugin down while the others are still mid-verification. The previous run's log shows `Shutting down all plugins` 4 times across 7 tests. It's load-dependent, which is why it doesn't reproduce on a fast dev box.

Fixed by running that directory's provider tests with `--test-threads=1`, with a comment explaining why. Verified locally: 7 passed serially.

## Worth flagging separately

Two of those tests assert that verification *fails* (`verify_exact_match_fails`, `verify_array_contains_fails_when_missing`). A connection error satisfies them, so they'd pass even with the provider down — they were "passing" in the broken CI run for the wrong reason. I've left that alone here to keep this PR to one thing, but happy to tighten them to assert on the mismatch content in a follow-up.

## On parallelising the job

You're right that a matrix strategy is the better answer for the whole list. Happy to take that on as a separate PR if you want it — one matrix entry per directory would also cut the current ~10 minutes to roughly the slowest single directory. Not assuming; say the word.
